### PR TITLE
Don’t create initial form for new lexemes

### DIFF
--- a/app.py
+++ b/app.py
@@ -490,13 +490,7 @@ def create_new_lexeme():
             'lemmas': {lang: {'language': lang, 'value': content}},
             'language': language,
             'lexicalCategory': req_data.get("pos"),
-            'forms': [{
-                'add': '',
-                'representations': {lang: {'language': lang,
-                                           'value': content}},
-                'grammaticalFeatures': [],
-                'claims': []
-            }]
+            'forms': []
         }
         host = 'https://www.wikidata.org'
         session = mwapi.Session(


### PR DESCRIPTION
When creating a lexeme, don’t create an initial form with the lemma as the representation and an empty list of grammatical features. A form without grammatical features is not very useful; lexemes with a single such form are much less common than lexemes without any forms (compare [Quarry][1] and [Quarry][2]); and the [Wikidata Lexeme Forms user script][3] can’t be used directly with these lexemes either.

[1]: https://quarry.wmflabs.org/query/37453
[2]: https://quarry.wmflabs.org/query/37454
[3]: https://www.wikidata.org/wiki/Wikidata:Wikidata_Lexeme_Forms#User_script